### PR TITLE
Corrige corchetes sin cerrar

### DIFF
--- a/doc/prefacios/prefacio.tex
+++ b/doc/prefacios/prefacio.tex
@@ -10,10 +10,10 @@ Nombre Del Estudiante\\
 %\vspace{0.7cm}
 
 \vspace{0.5cm}
-\noindent{\textbf{Palabras clave}: \textit{software libre}
+\noindent\textbf{Palabras clave}: \textit{software libre}
 \vspace{0.7cm}
 
-\noindent{\textbf{Resumen}\\
+\noindent\textbf{Resumen}\\
 	
 
 \cleardoublepage
@@ -25,10 +25,10 @@ Nombre Del Estudiante\\
 	Student's name\\
 \end{center}
 \vspace{0.5cm}
-\noindent{\textbf{Keywords}: \textit{open source}, \textit{floss}
+\noindent\textbf{Keywords}: \textit{open source}, \textit{floss}
 \vspace{0.7cm}
 
-\noindent{\textbf{Abstract}\\
+\noindent\textbf{Abstract}\\
 
 
 \cleardoublepage


### PR DESCRIPTION
Algunos comandos \noindent en el prefacio tienen un corchete de apertura "{" pero no tienen el de cerrar.

Si no escribes nada mas compila sin problemas, pero al rodear el texto inglés en un entorno de latex, concretamente:

\begin{otherlanguage}{english}
   .... english abstract ...
\end{otherlanguage}

me daba error al compilar por la falta del cierre del corchete.

He quitado los corchetes, porque como \noindent se aplica por defecto al parrafo entero creo que cumple la misma función, pero también podrían cerrarse.